### PR TITLE
Add handling of a search param `q`

### DIFF
--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -60,7 +60,7 @@ export const Library = ({ mode }: { mode: LibraryMode }) => {
 	const [bookId, setBookId] = useState<string>("");
 	const [bookImageDimensions, setBookImageDimensions] =
 		useState<BookImageDimensions>();
-	const [searchText, setSearchText] = useState<string>("");
+	const [searchText, setSearchText] = useState<string>(new URLSearchParams(window.location.search).get("q") ?? "");
 
 	const bookIdChanged = useRef<boolean>(false);
 	const bookImageChanged = useRef<boolean>(false);


### PR DESCRIPTION
Typical search engines keep the search query in an URL search param `q`, which allows browsers to generate links for those. This commit adds a small check for this search param.